### PR TITLE
Add the ability to define a custom z-index

### DIFF
--- a/assets/js/ssb-ui-js.js
+++ b/assets/js/ssb-ui-js.js
@@ -6,6 +6,8 @@ jQuery(function ($) {
         ssb_panel_w = ssb_panel.width(),
         sbb_display_margin = 50;
 
+    ssb_panel.css('z-index', ssb_ui_data.z_index);
+
     if (ssb_panel.hasClass('ssb-btns-left') && (ssb_panel.hasClass('ssb-anim-slide') || ssb_panel.hasClass('ssb-anim-icons'))) {
 
         ssb_panel.css('left', '-' + (ssb_panel_w - sbb_display_margin) + 'px');

--- a/ssb-main.php
+++ b/ssb-main.php
@@ -187,6 +187,10 @@ class ssb_main {
 		wp_enqueue_script('jquery-effects-shake');
 		wp_enqueue_script('ssb-ui-js', plugins_url('assets/js/ssb-ui-js.js', __FILE__));
 
+		$btn_z_index = isset( $this->settings['btn_z_index'] ) ? $this->settings['btn_z_index'] : 1;
+		wp_localize_script( 'ssb-ui-js', 'ssb_ui_data', array(
+			'z_index' => intval( $btn_z_index )
+		));
 	}
 
 

--- a/ssb-ui.php
+++ b/ssb-ui.php
@@ -304,6 +304,20 @@ class ssb_ui {
 					</div>
 				</div>
 
+				<div class="ssb-row">
+					<div class="ssb-col">
+						<label for="ssb-btn-z-index">
+							<strong><?php _e( 'z-index', 'sticky-side-buttons' ); ?>:</strong>
+						</label>
+					</div>
+					<div class="ssb-col">
+						<input type="number"
+							   name="ssb_settings[btn_z_index]"
+							   id="ssb-btn-z-index" class="small-text"
+							   value="<?php echo isset( $this->settings['btn_z_index'] ) ? intval( $this->settings['btn_z_index'] ) : 1 ?>">
+
+					</div>
+				</div>
 
 			</div>
 			<footer class="ssb-panel-footer">


### PR DESCRIPTION
Certain widgets and themes include z-index higher than 1 which will result in the sticky buttons being covered. Typically, increasing the z-index is fine but there may be certain instances where users may wish for the sticky side buttons not to appear in front of other elements. As a result, the best overall solution would be to allow users to set a custom z-index. 