### PR TITLE
Pass button through a wordpress filter

### DIFF
--- a/ssb-ui.php
+++ b/ssb-ui.php
@@ -425,12 +425,15 @@ class ssb_ui {
 						<?php
 						// Buttons loop + ordering
 						foreach ( $this->btns_order AS $btn_key => $btn_id ) {
+							$btn = $this->buttons['btns'][ $btn_id ];
+							$btn = apply_filters("sticky_side_buttons_button", $btn_id, $this->buttons['btns'][ $btn_id ]);
+							
 							?>
                             <li id="ssb-btn-<?php echo $btn_id; ?>">
                                 <p>
-                                    <a href="<?php echo $this->buttons['btns'][ $btn_id ]['btn_link']; ?>" <?php echo ( !empty($this->buttons['btns'][ $btn_id ]['open_new_window']) ) ? 'target="_blank"' : ''; ?>><?php
-										echo ( isset( $this->buttons['btns'][ $btn_id ]['btn_icon'] ) && $this->buttons['btns'][ $btn_id ]['btn_icon'] ) ? '<span class="' . $this->buttons['btns'][ $btn_id ]['btn_icon'] . '"></span> ' : '';
-										echo ( isset( $this->buttons['btns'][ $btn_id ]['btn_text'] ) && ( isset( $this->settings['btn_anim'] ) && $this->settings['btn_anim'] != 'icons' ) ) ? __( $this->buttons['btns'][ $btn_id ]['btn_text'], 'sticky-side-buttons' ) : ' &nbsp; ';
+                                    <a href="<?php echo $btn['btn_link']; ?>" <?php echo ( !empty($btn['open_new_window']) ) ? 'target="_blank"' : ''; ?>><?php
+										echo ( isset( $btn['btn_icon'] ) && $btn['btn_icon'] ) ? '<span class="' . $btn['btn_icon'] . '"></span> ' : '';
+										echo ( isset( $btn['btn_text'] ) && ( isset( $this->settings['btn_anim'] ) && $this->settings['btn_anim'] != 'icons' ) ) ? __( $btn['btn_text'], 'sticky-side-buttons' ) : ' &nbsp; ';
 										?></a>
                                 </p>
                             </li>


### PR DESCRIPTION
Pass button through a wordpress filter allowing the flexibility to apply logic or modifications to buttons.

For example:
```php
public function sticky_side_buttons_button($button_id, $button) {
	if (isset($button) && isset($button['btn_link'])) {
		switch ($button['btn_link']) {
			case "/login":
				if ( is_user_logged_in() ) {
					$button['btn_link'] = wp_logout_url();
					$button['btn_text'] = "Logout";
				}
			break;
		}
	}
	return $button;
}
```